### PR TITLE
REMOVE disable touch on body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-body-scroll-lock",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -4,7 +4,7 @@
 const bodyDatasetName = "tsslock";
 const elementDatasetName = "tsslockid";
 const bodyLockStyle =
-  ";touch-action:none!important;overscroll-behavior:none!important;overflow:hidden!important;";
+  ";overscroll-behavior:none!important;overflow:hidden!important;";
 
 // used to fix iOS body scrolling when content is not large enough to be scrolled but has overflow-y: scroll
 const scrollYContentLockStyle = ";overflow-y:unset!important;";


### PR DESCRIPTION
The user couldn't pinch-zoom when the scroll lock was active
"touch-action: none" prevented this